### PR TITLE
Fix Wrong Transform Normalize Operation in AutoEncoder

### DIFF
--- a/08-AutoEncoder/simple_autoencoder.py
+++ b/08-AutoEncoder/simple_autoencoder.py
@@ -28,7 +28,7 @@ learning_rate = 1e-3
 
 img_transform = transforms.Compose([
     transforms.ToTensor(),
-    transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
+    transforms.Normalize([0.5], [0.5])
 ])
 
 dataset = MNIST('./data', transform=img_transform)


### PR DESCRIPTION
08-autoencoder project use mnist dataset and All images in this dataset have the same shape (1,28,28)
But, the normalize operation in your code is Below： 
```python
img_transform = transforms.Compose([
    transforms.ToTensor(),
    transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
])
```

it show be like below:

```python
img_transform = transforms.Compose([
    transforms.ToTensor(),
    transforms.Normalize([0.5], [0.5])
])
```